### PR TITLE
Synchronous version of fs.writeFile support - suggestion to use fs.writeFileSync

### DIFF
--- a/tasks/filenamesToJson.js
+++ b/tasks/filenamesToJson.js
@@ -59,12 +59,16 @@ module.exports = function(grunt) {
     		fs.mkdirSync(dir);
 		}
 
-		// write json
-		jf.writeFile(config.destination, output, function(err) {
-			if (err){
-		  		grunt.fail.warn(err);
-			}
-		});
+		if (config.options.synchronous) {
+            		jf.writeFileSync(config.destination, output);
+        	} else {
+			// write json
+			jf.writeFile(config.destination, output, function(err) {
+				if (err){
+		  			grunt.fail.warn(err);
+				}
+			});
+        	}
 		
 	});
 };


### PR DESCRIPTION
Adding this option will prevent the destination file to be blank.
